### PR TITLE
fix ordering of e-e messages for bf shift

### DIFF
--- a/src/deeperwin/model.py
+++ b/src/deeperwin/model.py
@@ -276,7 +276,7 @@ def build_simple_schnet(config: SimpleSchnetConfig, n_el, n_up, input_dim, name=
 
             embeddings_el_el = jnp.concatenate([
                 jnp.concatenate([w_u_u * h_u_u, w_u_d * h_u_d], axis=-2),
-                jnp.concatenate([w_d_d * h_d_d, w_d_u * h_d_u], axis=-2)],
+                jnp.concatenate([w_d_u * h_d_u, w_d_d * h_d_d], axis=-2)],
                 axis=-3)
             embeddings_el_ions = w_el_ions * ion_embeddings
 


### PR DESCRIPTION
Without the fix, the ordering of `pair_embedding` and of `diff` and `dist` are mismatched for spin up in https://github.com/mipunivie/deeperwin/blob/11485b7c2ff239d1eed0b518121c768a95801b92/src/deeperwin/model.py#L337